### PR TITLE
Added missing header, updated CMAKE_CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(sqlgen)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(LLVM REQUIRED CONFIG)
 

--- a/SQLInsertEmitter.h
+++ b/SQLInsertEmitter.h
@@ -2,6 +2,7 @@
 #define SQLGEN_SQLINSERTEMITTER_H
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Record.h"


### PR DESCRIPTION
Optional ADT is used in SQLInsertEmmitter.h but corresponding header is not included.
Fixed by including `"llvm/ADT/Optional.h"`

CMAKE_CXX_STANDARD 14 does not compiler (I am using gcc, if that matters)
updated it to 17